### PR TITLE
Fix shuffle bug

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -139,7 +139,7 @@ function generateShuffledSchedule(a, b) {
     }
 
     for (let i = b - 1; i >= a; i--) {
-        const j = Math.floor(Math.random() * i);
+        const j = Math.floor(Math.random() * (i + 1));
         const temp = result[j];
         result[j] = result[i];
         result[i] = temp;


### PR DESCRIPTION
Вроде так должно работать.

Проблема была в том что `Math.random()` возвращает число в интервале [0,1). Поэтому `Math.floor(Math.random() * i)` вернет число в интервале [0,i), а по алгоритму нужно число в интервале [0,i].